### PR TITLE
fix: constant name `@ton/test-utils` in require

### DIFF
--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -40,7 +40,7 @@ import { collectAsmCoverage, collectTxsCoverage, mergeCoverages, Coverage } from
 import { MessageQueueManager } from './MessageQueueManager';
 import { AsyncLock } from '../utils/AsyncLock';
 import { BlockchainSnapshot } from './BlockchainSnapshot';
-import { requireOptional } from '../utils/require';
+import { requireTestUtils } from '../utils/require';
 
 const CREATE_WALLETS_PREFIX = 'CREATE_WALLETS';
 
@@ -918,7 +918,7 @@ export class Blockchain {
         return new Blockchain({
             executor: opts?.executor ?? (await Executor.create()),
             storage: opts?.storage ?? new LocalBlockchainStorage(),
-            meta: opts?.meta ?? requireOptional('@ton/test-utils')?.contractsMeta,
+            meta: opts?.meta ?? requireTestUtils()?.contractsMeta,
             ...opts,
         });
     }

--- a/src/utils/require.ts
+++ b/src/utils/require.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function requireOptional(id: string): any | undefined {
+export function requireTestUtils(): any | undefined {
     try {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
-        return require(id);
+        return require('@ton/test-utils');
     } catch (error) {
         if (String(error).includes('Cannot find module')) {
             return undefined;


### PR DESCRIPTION
## Issue

When compiling `ESM` using `esbuild` and running it on the web, we get the error: `Dynamic require of "@ton/test-utils" is not supported`.
`esbuild` cannot generate code that finds dependencies at runtime, but only when the name is specified as a string literal (provided that the package is actually present in the project; if not, we will also get this error).

Yes, this won't save you from an error when the package really isn't there, but it will remove the error when the package is actually there, but `esbuild` (or other builders) can't find it because the name isn't a string literal.

See:
1. https://esbuild.github.io/api/#format-esm
2. https://esbuild.github.io/api/#non-analyzable-imports

## Checklist

Please ensure the following items are completed before requesting review:

* [ ] Updated `CHANGELOG.md` with relevant changes
* [ ] Documented the contribution in `README.md`
* [ ] Added tests to demonstrate correct behavior (both positive and negative cases)
* [x] All tests pass successfully
* [x] Code passes linting checks (`yarn lint`)